### PR TITLE
in external mode, dont process anything automatically.

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,6 +66,11 @@ module.exports = function(app) {
           var path = u['values'][0]['path']
           var value = u['values'][0]['value']
           options.config.forEach(config => {
+
+            //always use external control if selected
+            if (config.source == 'none')
+              return;
+        
             var group = config.group
             app.debug(`RunMode: ${runMode} group: ${group} luxPath: ${config.Lux['path']}`)
             if (config.source == 'lux' && path == config.Lux.path) { 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-bandg-displaydaynight",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Auto adjust B&G display mode",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I haven't updated my plugins in a long time, but when I did some of the recent changes broke my external control setup.  This fixes that by checking for external control mode and exiting early if needed.