### PR TITLE
Addition of two more Sun based Transition points

### DIFF
--- a/index.js
+++ b/index.js
@@ -296,13 +296,31 @@ module.exports = function(app) {
 			      },
 			      Sun: {
 			        title: 'Sun based settings',
-			        description: 'Adjust the display mode based on `environment.sun` (derived-data). Below the display mode and backlight level can be set for each mode.',
+			        description: 'Adjust the display mode based on `environment.sun` (derived-data). Below the display mode and backlight level can be set for each mode. Supports: nauticalDawn, dawn, sunrise, day, sunset, nauticalDusk, dusk, night.',
 			        type: 'object',
 			        properties: {
 			          updateOnce: {
 			            type: 'boolean',
 			            title: 'Update display mode only when environment.sun changes.',
 			            default: true,
+			          },
+			          nauticalDawn: {
+			            type: 'object',
+			            title: 'Nautical Dawn',
+			            properties: {
+			              mode: {
+			                type: 'string',
+			                title: 'Select day or night mode',
+			                enum: ['day', 'night'],
+			                enumNames: ['Day', 'Night'],
+			                default: 'night'
+			              },
+			              backlight: {
+			                type: 'number',
+			                title: 'Backlight level in nautical dawn (1-10)',
+			                default: 3,
+			              },
+			            },
 			          },
 			          dawn: {
 			            type: 'object',
@@ -317,7 +335,7 @@ module.exports = function(app) {
 			              },
 			              backlight: {
 			                type: 'number',
-			                title: 'Backlight level in nightmode (1-10)',
+			                title: 'Backlight level in dawn (1-10)',
 			                default: 4,
 			              },
 			            },
@@ -335,7 +353,7 @@ module.exports = function(app) {
 			              },
 			              backlight: {
 			                type: 'number',
-			                title: 'Backlight level in nightmode (1-10)',
+			                title: 'Backlight level in sunrise (1-10)',
 			                default: 4,
 			              },
 			            },
@@ -371,8 +389,26 @@ module.exports = function(app) {
 			              },
 			              backlight: {
 			                type: 'number',
-			                title: 'Backlight level in nightmode (1-10)',
+			                title: 'Backlight level in sunset (1-10)',
 			                default: 4,
+			              },
+			            },
+			          },
+			          nauticalDusk: {
+			            type: 'object',
+			            title: 'Nautical Dusk',
+			            properties: {
+			              mode: {
+			                type: 'string',
+			                title: 'Select day or night mode',
+			                enum: ['day', 'night'],
+			                enumNames: ['Day', 'Night'],
+			                default: 'night'
+			              },
+			              backlight: {
+			                type: 'number',
+			                title: 'Backlight level in nautical dusk (1-10)',
+			                default: 3,
 			              },
 			            },
 			          },
@@ -389,7 +425,7 @@ module.exports = function(app) {
 			              },
 			              backlight: {
 			                type: 'number',
-			                title: 'Backlight level in day mode (1-10)',
+			                title: 'Backlight level in dusk (1-10)',
 			                default: 4,
 			              },
 			            },

--- a/index.js
+++ b/index.js
@@ -394,24 +394,6 @@ module.exports = function(app) {
 			              },
 			            },
 			          },
-			          nauticalDusk: {
-			            type: 'object',
-			            title: 'Nautical Dusk',
-			            properties: {
-			              mode: {
-			                type: 'string',
-			                title: 'Select day or night mode',
-			                enum: ['day', 'night'],
-			                enumNames: ['Day', 'Night'],
-			                default: 'night'
-			              },
-			              backlight: {
-			                type: 'number',
-			                title: 'Backlight level in nautical dusk (1-10)',
-			                default: 3,
-			              },
-			            },
-			          },
 			          dusk: {
 			            type: 'object',
 			            title: 'Dusk',
@@ -427,6 +409,24 @@ module.exports = function(app) {
 			                type: 'number',
 			                title: 'Backlight level in dusk (1-10)',
 			                default: 4,
+			              },
+			            },
+			          },
+			          nauticalDusk: {
+			            type: 'object',
+			            title: 'Nautical Dusk',
+			            properties: {
+			              mode: {
+			                type: 'string',
+			                title: 'Select day or night mode',
+			                enum: ['day', 'night'],
+			                enumNames: ['Day', 'Night'],
+			                default: 'night'
+			              },
+			              backlight: {
+			                type: 'number',
+			                title: 'Backlight level in nautical dusk (1-10)',
+			                default: 3,
 			              },
 			            },
 			          },


### PR DESCRIPTION
Hello, this (along with the changes I made to derived data) is my first code contribution to github projects, so please educate me if I did something wrong.  
The changes I made are to allow the user to also configure a display mode and brightness at Nautical Dawn and Nautical Dusk.  My wife an I are liveaboard sailors and will routinely sail for multiple days. The transition between Night and Dawn can be quite profound (similarly from Dusk to Night) and the brightness is either too high or too low.  I have added two fields, Nautical Dawn and Nautical Dusk to allow improved control during these times of the day. 
I have made the necessary changes to derived-data so that 'environment.sunlight.times.nauticalDawn' and 'environment.sunlight.times.nauticalDusk' get created.

I'm not sure of the best way to transition this, though I don't believe anything would break if signalk_bandg-displaydaynight looked for those values and didn't find them (from a down-level derived-data), but if additional changes/error-checking is required, I am happy to provide whatever is needed.

Thanks,
Mike