### PR TITLE
Major feature add

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # signalk-bandg-displaydaynight
 Auto adjust the display mode (night/day/backlight) based on different modes.
-Config can be created per network group.
+Config can be created per network group.  Each netowrk group can operate under different modes and have different backlight settings.  
+By using the Device Power-On ReSync, devices that are in a group with a setting of "Update Display mode only on environment.sun/mode changes" checked, will not have to wait for a change in the environment.sun or environment.mode deltas in order to take the backlight setting they should.
+In order to use the feature, the plugin must be configured with a path that begins transmitting when the device(typically a Chartplotter) first powers on.  For the B&G Zeus 3S, very little is transmitted prior to the user accepting the User Agreement. navigation.currentRoute.name is one that can be used, even is a route is not being followed. If the Chartplotter was last used at night and then turned off, the chartplotter will power on in what could be a very dark mode of operation.  With this section configured, the plugin will notice the path appear and immediately send out a backlight update so that the display brightness is quickly corrected.
 
-The plugin supports currently 2 modes:
+The plugin supports currently 3 modes:
 ### Mode
 This mode subscribes to ``environment.mode`` and will switch between day and night. Backlight level for both can be set.
 ### Sun

--- a/README.md
+++ b/README.md
@@ -1,21 +1,19 @@
 # signalk-bandg-displaydaynight
 Auto adjust the display mode (night/day/backlight) based on different modes.
-Config can be created per network group.  Each netowrk group can operate under different modes and have different backlight settings.  
-By using the Device Power-On ReSync, devices that are in a group with a setting of "Update Display mode only on environment.sun/mode changes" checked, will not have to wait for a change in the environment.sun or environment.mode deltas in order to take the backlight setting they should.
-In order to use the feature, the plugin must be configured with a path that begins transmitting when the device(typically a Chartplotter) first powers on.  For the B&G Zeus 3S, very little is transmitted prior to the user accepting the User Agreement. navigation.currentRoute.name is one that can be used, even is a route is not being followed. If the Chartplotter was last used at night and then turned off, the chartplotter will power on in what could be a very dark mode of operation.  With this section configured, the plugin will notice the path appear and immediately send out a backlight update so that the display brightness is quickly corrected.
 
-The plugin supports currently 3 modes:
-### Mode
+### Run Modes
+The plugin currently supports 4 run modes:
+#### Mode
 This mode subscribes to ``environment.mode`` and will switch between day and night. Backlight level for both can be set.
-### Sun
-This mode subscribes to ``environment.sun`` and will switch between dawn, sunrise, day, sunset, dusk and night. Diplay mode and backlight level can be set for all.
+#### Sun
+This mode subscribes to ``environment.sun`` and will switch between nautical dawn, dawn, sunrise, day, sunset, dusk, nautical dusk, and night. Diplay mode and backlight level can be set for all.
 
-### Lux
+#### Lux
 This mode subscribes to a path providing the outside lux value and allows diplay mode and backlight level to be set for a lux range.
 
 Commands are send out as N2K packets.
 
-### None / External
+#### None / External
 This mode doesn't do any automatic adjustment of the display mode or backlight, however you can use the PUT interface to manually change it with something like Node-RED.  The path is: 'environment.displayMode.control'.  The API expects a JSON object with 3 parameters:
 
 * mode: day or night
@@ -33,3 +31,28 @@ Here is an example flow for Node-RED:
 ```javascript
 [{"id":"74db8643c2f49eaf","type":"inject","z":"2ecf05826ff4ea59","name":"day / 10","props":[{"p":"payload"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"{\"mode\":\"day\", \"backlight\":\"10\"}","payloadType":"json","x":120,"y":40,"wires":[["6f20c28b95f402f4"]]},{"id":"6f20c28b95f402f4","type":"signalk-send-put","z":"2ecf05826ff4ea59","name":"Change B&G display","path":"environment.displayMode.control","source":"","x":420,"y":100,"wires":[]},{"id":"5124c332bde80c2b","type":"inject","z":"2ecf05826ff4ea59","name":"night / 5","props":[{"p":"payload"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"{\"mode\":\"night\", \"backlight\":5}","payloadType":"json","x":120,"y":80,"wires":[["6f20c28b95f402f4"]]},{"id":"441ce8cdcb562692","type":"inject","z":"2ecf05826ff4ea59","name":"night / 1","props":[{"p":"payload"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"{\"mode\":\"night\", \"backlight\":1}","payloadType":"json","x":120,"y":120,"wires":[["6f20c28b95f402f4"]]},{"id":"5469b202682dc3a1","type":"inject","z":"2ecf05826ff4ea59","name":"group 1 / night / 1","props":[{"p":"payload"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"{\"mode\":\"night\", \"backlight\":1, \"group\": 1}","payloadType":"json","x":150,"y":160,"wires":[["6f20c28b95f402f4"]]}]
 ```
+### Group Configuration
+B&G Devices can be configured to operate in one of up to 7 Network Groups(Default, 1-6).  The plugin config is created on a per network group basis.  Each netowrk group can operate under different modes and have different backlight settings.  
+
+#### Update display mode only when environment.mode / environment.sun changes Checkboxes
+Checking the checkbox causes the plugin to *not* re-apply brightness settings unless the path value actually changes (i.e., Night->Nautical Dusk in sun run mode, or Day to Night in mode run mode).
+
+The Signalk path environment.mode (run mode = Mode) and environment.sun (run mode = Sun) are used by this plugin as the input to determine what brightness levels should be sent.  These values are typical created by the Derived Data plugin and sent out every 60 seconds, regardless of if the value has changed.  
+Unless this checkbox is checked:
+- This plugin will see those deltas arrive and act on them, re-calculating and re-applying the brightness settings on display.
+- If a user overrides a display brightness on a B&G device, the display brightness will revert back when the next envirnment.mode / environment.sun message arrives and is processed.
+
+#### Device Power-on Resync
+By using the Device Power-On ReSync, devices that are in a group with a setting of "Update Display mode only on environment.sun/mode changes" checked, will not have to wait for a change in the environment.sun or environment.mode deltas after they are powered on in order to take the backlight setting they should for the current time of day.
+
+In order to use the feature, the plugin must be configured with a path that begins transmitting when the device (typically a Chartplotter) first powers on.  For the B&G Zeus 3S, very little is transmitted prior to the user accepting the User Agreement, however navigation.currentRoute.name is one that can be used, even is a route is not being followed. It should also be noted that if any Source Priorities are configured in the Server Connections, lower priority deltas for the path will not be seen by this plugin as Source Priorities acts as a smart, dynamic message filter at a low level within SignalK.
+
+If the Chartplotter was last used at night and then turned off, the chartplotter will power on in what could be a very dark mode of operation.  With this section configured, the plugin will notice the path appear and immediately send out a backlight update so that the display brightness is quickly corrected to be accurate for the current time of day.
+
+##### How to determine the best path to use
+In order to determine a path that appears as early as possible, follow these steps:
+1. Turn on the Chartplotter in question.
+2. Allow it get to any user prompt requiring a press to proceed, but do not press Ok/accept.
+3. Using the SignalK Data Browser, find the NMEA source(s) for your chartplotter, N2K.17, for example.
+4. Enter the source (i.e., N2K.17), one at a time, into the Data Browser filter and see if any paths show up with timestamps that continue to update.
+5. Continue through all sources until you find a path that exists at this point and use that in the plugin configuration. (NOTE, Path and Source are case sensitive.)

--- a/index.js
+++ b/index.js
@@ -29,8 +29,8 @@ module.exports = function(app) {
     app.debug('Plugin started');
     app.debug('Schema: %s', JSON.stringify(options));
     
-    // Local state variables
-    var runMode = 'mode';
+    // Structure: { 'Default': 'mode', 'Group1': 'sun' }
+    var groupRunModes = {};
     
     // Cache for the last command sent per group
     // Structure: { 'Default': { mode: 'day', level: 10 } }
@@ -87,41 +87,41 @@ module.exports = function(app) {
       },
       delta => {
         delta.updates.forEach(u => {
-          app.debug('delta sub: %s', JSON.stringify(u))
-		  var path = u['values'][0]['path']
+          // Standard variables
+          var path = u['values'][0]['path']
           var value = u['values'][0]['value']
-          var source = u['source'] ? u['source']['label'] : delta.source ? delta.source.label : 'unknown'; 
+          
+          // --- Robust Source Parsing ---
+          var rawSource = u['source'] || delta.source;
+          var sourceLabel = rawSource ? rawSource.label : 'unknown';
+          // Ensure we don't get "undefined" strings
+          var sourceSrc = (rawSource && typeof rawSource.src !== 'undefined') ? rawSource.src.toString() : '';
+          
+          // If we have both, combine them (e.g. "N2K.18"). If not, just use label.
+          var source = (sourceSrc !== '') ? `${sourceLabel}.${sourceSrc}` : sourceLabel;
           
           options.config.forEach(config => {
             var group = config.group;
-            app.debug(`RunMode: ${runMode}, group: ${group}`)
 
             // --------------------------------------------------------
             // Resync Logic
             // --------------------------------------------------------
             if (config.Resync && Array.isArray(config.Resync)) {
-              app.debug('in first if')
-				config.Resync.forEach(trigger => {
+              config.Resync.forEach(trigger => {
                 // Check if this delta matches the trigger path
-				app.debug('in second if')
                 if (trigger.path === path) {
-                  // Check if source matches (if configured)
-					app.debug('in third if')
+                  // Check if source matches (if configured) - Case Sensitive (Option 1)
                   if (trigger.source && trigger.source !== '' && trigger.source !== source) {
-                    app.debug(`Trigger source ${trigger.source} did not match saved source ${source}`)
-					  return; // Source didn't match
+                      return; // Source didn't match
                   }
-				  app.debug('Trigger delta received, updated last-seen time');
-					
+
                   // Generate unique key for this specific trigger instance
-				  // Recall the timestamp of the last transmission. If the next transmission occures after more than 'timeout',
-				  // it is assumed the device is powered off and the backlighting values for 'now' should be sent
                   var trackerKey = `${group}_${source}_${path}`;
                   var now = Date.now();
                   var lastSeen = activityTracker[trackerKey];
                   var timeoutMs = (trigger.timeout || 60) * 1000;
 
-				  // If never seen, or timeout expired
+                  // If never seen, or timeout expired
                   if (!lastSeen || (now - lastSeen > timeoutMs)) {
                     app.debug(`Resync Triggered for Group ${group}. Device ${source} on ${path} active after ${lastSeen ? (now-lastSeen)/1000 : 'infinite'}s silence.`);
                      
@@ -135,7 +135,7 @@ module.exports = function(app) {
                       setBacklightLevel(settings.level, group);
                     } else {
                       app.debug(`Cannot Resync: No settings have been calculated yet for group ${group}`);
-                	}
+                    }
                   }
 
                   // Update activity timestamp
@@ -147,58 +147,65 @@ module.exports = function(app) {
             // End Resync Logic
             // --------------------------------------------------------
 
-            //always use external control if selected
+            // Initialize runMode for this group if it doesn't exist yet
+            if (!groupRunModes[group]) {
+                groupRunModes[group] = 'mode';
+            }
+            // Get the current mode for THIS group
+            var runMode = groupRunModes[group];            
+
+            // always use external control if selected
             if (config.source == 'none')
               return;
         
-            if (config.source == 'lux' && config.Lux && path == config.Lux.path) { 
-              app.debug(`Switching to runMode \'lux\', luxPath: ${config.Lux['path']}`)
-              runMode = 'lux'
+            if (config.source == 'lux' && path == config.Lux.path) { 
+              app.debug(`Group ${group}: Switching to runMode 'lux', luxPath: ${config.Lux['path']}`)
+              groupRunModes[group] = 'lux'; // Update storage
+              runMode = 'lux'; // Update local variable for immediate switch below
             }
-            
-	          switch (runMode) {
-	            case 'mode':
-	              if (path != 'environment.mode') break;
-	              var dayNight = value
+
+            switch (runMode) {
+                case 'mode':
+                  if (path != 'environment.mode') break;
+                  var dayNight = value
 
                   if (config.Mode['updateOnce']) {
                     if (dayNight == lastState[group]) break
                     lastState[group] = dayNight
                   }
 
-			      if (dayNight == 'night') {
+                  if (dayNight == 'night') {
                     executeCommand(dayNight, config.Mode['nightLevel'], group);
-			      } else {
+                  } else {
                     executeCommand(dayNight, config.Mode['dayLevel'], group);
-	              }
+                  }
                   
                   if (config['source'] != 'mode') { 
-                    app.debug('Used backup mode \'mode\', switching to \'sun\'')
-                    runMode = 'sun'
+                    app.debug(`Group ${group}: Used backup mode 'mode', switching to 'sun'`)
+                    groupRunModes[group] = 'sun';
                   }
-	              break;
+                  break;
 
-	            case 'sun':
-	              if (path != 'environment.sun') break;
-	              var sunMode = value
-		          app.debug('environment.sun: %s', sunMode);
+                case 'sun':
+                  if (path != 'environment.sun') break;
+                  var sunMode = value
 
-	              if (!config.Sun[sunMode]) break; // Safety check
+                  if (!config.Sun[sunMode]) break; // Safety check
 
-	              var mode = config.Sun[sunMode]['mode'];
+                  var mode = config.Sun[sunMode]['mode'];
 
                   if (config.Sun['updateOnce']) {
                     if (sunMode == lastState[group]) break
                     lastState[group] = sunMode
                   }
 
-	              var backlightLevel = config.Sun[sunMode]['backlight'];
+                  var backlightLevel = config.Sun[sunMode]['backlight'];
                   executeCommand(mode, backlightLevel, group);
-	              break;
+                  break;
 
-	            case 'lux':
+                case 'lux':
                   if (!config.Lux) break;
-	              if (path != config.Lux.path) break;
+                  if (path != config.Lux.path) break;
                   config.Lux.table.forEach(element => {
                     if (Number(value) >= Number(element.luxMin) && Number(value) <= Number(element.luxMax)) {
                       var mode = element.dayNight
@@ -206,8 +213,8 @@ module.exports = function(app) {
                       executeCommand(mode, backlightLevel, group);
                     }
                   })
-	              break;
-	          }
+                  break;
+            }
           })
         })
       }
@@ -218,7 +225,7 @@ module.exports = function(app) {
         // Cache this simply
         lastSentSettings[group] = { mode: mode, level: level };
         
-        app.debug(`Executing command for Group ${group}: Mode=${mode}, Level=${level}`);
+        // app.debug(`Executing command for Group ${group}: Mode=${mode}, Level=${level}`);
         setDisplayMode(mode, group);
         setBacklightLevel(level, group);
         sendUpdate(mode, level);
@@ -250,7 +257,7 @@ module.exports = function(app) {
     }    
     
     function sendN2k(msgs) {
-      app.debug("n2k_msg: " + msgs)
+      // app.debug("n2k_msg: " + msgs)
       msgs.map(function(msg) { app.emit('nmea2000out', msg)})
     }
 
@@ -295,8 +302,8 @@ module.exports = function(app) {
         }
       }]
 
-      app.debug('Updating with: ' + JSON.stringify(update))
-		  app.handleMessage(plugin.id, {
+      // app.debug('Updating with: ' + JSON.stringify(update))
+      app.handleMessage(plugin.id, {
         updates: [
           {
             values: update
@@ -352,219 +359,4 @@ module.exports = function(app) {
 			        default: 'mode'
 			      },
             // Resync Section
-            Resync: {
-              title: 'Device Power-On Resync',
-              description: 'Force a settings update when a device (i.e., chartplotter) appears after being offline.',
-              type: 'array',
-              items: {
-                type: 'object',
-                properties: {
-                  path: {
-                    type: 'string',
-                    title: 'Trigger Path (e.g. navigation.courseOverGround, or navigation.currentRoute.name - See README)',
-                    default: ''
-                  },
-                  source: {
-                    type: 'string',
-                    title: 'Source ID (e.g. NMEA2000.115). Leave empty to match any source.',
-                    default: ''
-                  },
-                  timeout: {
-                    type: 'number',
-                    title: 'Inactivity Timeout (seconds). Resend settings if data is seen after this many seconds of silence.',
-                    default: 60
-                  }
-                }
-              }
-            },
-			      Mode: {
-			        title: 'Mode based settings',
-			        description: 'Adjust the display mode based on `environment.mode` (derived-data). Below the backlight level can be set for day and night mode.',
-			        type: 'object',
-			        properties: {
-			          updateOnce: {
-			            type: 'boolean',
-			            title: 'Update display mode only when environment.mode changes.',
-			            default: true,
-			          },
-			          dayLevel: {
-			            type: 'number',
-			            title: 'Backlight level in day mode (1-10)',
-			            default: 6,
-			          },
-			          nightLevel: {
-			            type: 'number',
-			            title: 'Backlight level in night mode (1-10)',
-			            default: 3,
-			          }
-			        }
-			      },
-			      Sun: {
-			        title: 'Sun based settings',
-			        description: 'Adjust the display mode based on `environment.sun` (derived-data). Below the display mode and backlight level can be set for each mode.',
-			        type: 'object',
-			        properties: {
-			          updateOnce: {
-			            type: 'boolean',
-			            title: 'Update display mode only when environment.sun changes.',
-			            default: true,
-			          },
-			          dawn: {
-			            type: 'object',
-			            title: 'Dawn',
-			            properties: {
-			              mode: {
-			                type: 'string',
-			                title: 'Select day or night mode',
-			                enum: ['day', 'night'],
-			                enumNames: ['Day', 'Night'],
-			                default: 'night'
-			              },
-			              backlight: {
-			                type: 'number',
-			                title: 'Backlight level in nightmode (1-10)',
-			                default: 4,
-			              },
-			            },
-			          },
-			          sunrise: {
-			            type: 'object',
-			            title: 'Sunrise',
-			            properties: {
-			              mode: {
-			                type: 'string',
-			                title: 'Select day or night mode',
-			                enum: ['day', 'night'],
-			                enumNames: ['Day', 'Night'],
-			                default: 'day'
-			              },
-			              backlight: {
-			                type: 'number',
-			                title: 'Backlight level in nightmode (1-10)',
-			                default: 4,
-			              },
-			            },
-			          },
-			          day: {
-			            type: 'object',
-			            title: 'Day',
-			            properties: {
-			              mode: {
-			                type: 'string',
-			                title: 'Select day or night mode',
-			                enum: ['day', 'night'],
-			                enumNames: ['Day', 'Night'],
-			                default: 'day'
-			              },
-			              backlight: {
-			                type: 'number',
-			                title: 'Backlight level in day mode (1-10)',
-			                default: 6,
-			              },
-			            },
-			          },
-			          sunset: {
-			            type: 'object',
-			            title: 'Sunset',
-			            properties: {
-			              mode: {
-			                type: 'string',
-			                title: 'Select day or night mode',
-			                enum: ['day', 'night'],
-			                enumNames: ['Day', 'Night'],
-			                default: 'day'
-			              },
-			              backlight: {
-			                type: 'number',
-			                title: 'Backlight level in nightmode (1-10)',
-			                default: 4,
-			              },
-			            },
-			          },
-			          dusk: {
-			            type: 'object',
-			            title: 'Dusk',
-			            properties: {
-			              mode: {
-			                type: 'string',
-			                title: 'Select day or night mode',
-			                enum: ['day', 'night'],
-			                enumNames: ['Day', 'Night'],
-			                default: 'night'
-			              },
-			              backlight: {
-			                type: 'number',
-			                title: 'Backlight level in day mode (1-10)',
-			                default: 4,
-			              },
-			            },
-			          },
-			          night: {
-			            type: 'object',
-			            title: 'Night',
-			            properties: {
-			              mode: {
-			                type: 'string',
-			                title: 'Select day or night mode',
-			                enum: ['day', 'night'],
-			                enumNames: ['Day', 'Night'],
-			                default: 'night'
-			              },
-			              backlight: {
-			                type: 'number',
-			                title: 'Backlight level in nightmode (1-10)',
-			                default: 2,
-			              },
-			            },
-			          },
-			        },
-			      },
-			            
-			      Lux: {
-			        title: 'Lux based settings',
-			        description: 'Adjust the display mode based on `environment.outside.lux`. Below the display mode and backlight level can be added per lux range.',
-			        type: 'object',
-			        properties: {
-			          path: {
-			            type: 'string',
-			            title: 'Path to outside lux value',
-			            default: 'environment.outside.lux'
-			          },
-			          table: {
-			            type: 'array',
-			            title: 'Table entries',
-			            items: {
-			              type: 'object',
-			              properties: {
-			                luxMin: {
-			                  type: 'number',
-			                  title: 'Minimal lux (lux) level'
-			                },
-			                luxMax: {
-			                  type: 'number',
-			                  title: 'Max lux (lux) level'
-			                },
-			                dayNight: {
-			                  type: 'string',
-			                  title: 'Mode',
-			                  enum: ['day', 'night'],
-			                  enumNames: ['Day', 'Night'],
-			                  default: 'day'
-			                },
-			                backlightLevel: {
-			                  type: 'number',
-			                  title: 'Backlight level (1-10)',
-			                  default: 2
-			                }
-			              }
-			            }
-			          }
-			        }
-			      }
-          }
-        }
-      }
-    }
-  }
-  return plugin
-}
+            Res

--- a/index.js
+++ b/index.js
@@ -296,13 +296,31 @@ module.exports = function(app) {
 			      },
 			      Sun: {
 			        title: 'Sun based settings',
-			        description: 'Adjust the display mode based on `environment.sun` (derived-data). Below the display mode and backlight level can be set for each mode.',
+			        description: 'Adjust the display mode based on `environment.sun` (derived-data). Below the display mode and backlight level can be set for each mode. Supports: nauticalDawn, dawn, sunrise, day, sunset, nauticalDusk, dusk, night.',
 			        type: 'object',
 			        properties: {
 			          updateOnce: {
 			            type: 'boolean',
 			            title: 'Update display mode only when environment.sun changes.',
 			            default: true,
+			          },
+			          nauticalDawn: {
+			            type: 'object',
+			            title: 'Nautical Dawn',
+			            properties: {
+			              mode: {
+			                type: 'string',
+			                title: 'Select day or night mode',
+			                enum: ['day', 'night'],
+			                enumNames: ['Day', 'Night'],
+			                default: 'night'
+			              },
+			              backlight: {
+			                type: 'number',
+			                title: 'Backlight level in nautical dawn (1-10)',
+			                default: 3,
+			              },
+			            },
 			          },
 			          dawn: {
 			            type: 'object',
@@ -317,7 +335,7 @@ module.exports = function(app) {
 			              },
 			              backlight: {
 			                type: 'number',
-			                title: 'Backlight level in nightmode (1-10)',
+			                title: 'Backlight level in dawn (1-10)',
 			                default: 4,
 			              },
 			            },
@@ -335,7 +353,7 @@ module.exports = function(app) {
 			              },
 			              backlight: {
 			                type: 'number',
-			                title: 'Backlight level in nightmode (1-10)',
+			                title: 'Backlight level in sunrise (1-10)',
 			                default: 4,
 			              },
 			            },
@@ -371,8 +389,26 @@ module.exports = function(app) {
 			              },
 			              backlight: {
 			                type: 'number',
-			                title: 'Backlight level in nightmode (1-10)',
+			                title: 'Backlight level in sunset (1-10)',
 			                default: 4,
+			              },
+			            },
+			          },
+			          nauticalDusk: {
+			            type: 'object',
+			            title: 'Nautical Dusk',
+			            properties: {
+			              mode: {
+			                type: 'string',
+			                title: 'Select day or night mode',
+			                enum: ['day', 'night'],
+			                enumNames: ['Day', 'Night'],
+			                default: 'night'
+			              },
+			              backlight: {
+			                type: 'number',
+			                title: 'Backlight level in nautical dusk (1-10)',
+			                default: 3,
 			              },
 			            },
 			          },
@@ -389,7 +425,7 @@ module.exports = function(app) {
 			              },
 			              backlight: {
 			                type: 'number',
-			                title: 'Backlight level in day mode (1-10)',
+			                title: 'Backlight level in dusk (1-10)',
 			                default: 4,
 			              },
 			            },

--- a/index.js
+++ b/index.js
@@ -274,7 +274,7 @@ module.exports = function(app) {
     }
 
     function setDisplayMode(mode, group) {
-      app.debug('setDisplayMode: Using group: %s (%s)', group, networkGroups[group])
+      app.debug('setDisplayMode for group: %s to %s', group, mode)
       var PGN130845_dayNight = "%s,3,130845,%s,255,0e,41,9f,ff,ff,%s,ff,ff,26,00,01,%s,ff,ff,ff"; // 02 = day, 04 = night
       if (mode == 'day') {
         var msg = util.format(PGN130845_dayNight, (new Date()).toISOString(), sourceAddress, networkGroups[group], '02');
@@ -287,7 +287,7 @@ module.exports = function(app) {
     }
 
     function setBacklightLevel(level, group) {
-      app.debug('setBacklightLevel: Using group: %s (%s)', group, networkGroups[group])
+      app.debug('setBacklightLevel for group: %s to level %s', group, level)
       var PGN130845_backlightLevel = "%s,3,130845,%s,255,0e,41,9f,ff,ff,%s,ff,ff,12,00,01,%s,ff,ff,ff"; 
       var msg = util.format(PGN130845_backlightLevel, (new Date()).toISOString(), sourceAddress, networkGroups[group], intToHex(level*10));
       sendN2k([msg]);

--- a/index.js
+++ b/index.js
@@ -87,27 +87,31 @@ module.exports = function(app) {
       },
       delta => {
         delta.updates.forEach(u => {
-          app.debug('u: %s', JSON.stringify(u))
+          app.debug('delta sub: %s', JSON.stringify(u))
 		  var path = u['values'][0]['path']
           var value = u['values'][0]['value']
           var source = u['source'] ? u['source']['label'] : delta.source ? delta.source.label : 'unknown'; 
           
           options.config.forEach(config => {
             var group = config.group;
-            app.debug(`RunMode: ${runMode} group: ${group}`)
+            app.debug(`RunMode: ${runMode}, group: ${group}`)
 
             // --------------------------------------------------------
             // Resync Logic
             // --------------------------------------------------------
             if (config.Resync && Array.isArray(config.Resync)) {
-              config.Resync.forEach(trigger => {
+              app.debug('in first if')
+				config.Resync.forEach(trigger => {
                 // Check if this delta matches the trigger path
+				app.debug('in second if')
                 if (trigger.path === path) {
                   // Check if source matches (if configured)
+					app.debug('in third if')
                   if (trigger.source && trigger.source !== '' && trigger.source !== source) {
-                    return; // Source didn't match
+                    app.debug(`Trigger source ${trigger.source} did not match saved source ${source}`)
+					  return; // Source didn't match
                   }
-				  app.debug('Trigger delta received, updated last seen time');
+				  app.debug('Trigger delta received, updated last-seen time');
 					
                   // Generate unique key for this specific trigger instance
 				  // Recall the timestamp of the last transmission. If the next transmission occures after more than 'timeout',
@@ -148,7 +152,7 @@ module.exports = function(app) {
               return;
         
             if (config.source == 'lux' && config.Lux && path == config.Lux.path) { 
-              app.debug(`Switching to runMode \'lux\' luxPath: ${config.Lux['path']}`)
+              app.debug(`Switching to runMode \'lux\', luxPath: ${config.Lux['path']}`)
               runMode = 'lux'
             }
             

--- a/index.js
+++ b/index.js
@@ -142,11 +142,10 @@ module.exports = function(app) {
 
             //always use external control if selected
             if (config.source == 'none')
-				aap.debug("
               return;
         
             if (config.source == 'lux' && config.Lux && path == config.Lux.path) { 
-              app.debug('Switching to runMode \'lux\' luxPath: ${config.Lux['path']}')
+              app.debug(`Switching to runMode \'lux\' luxPath: ${config.Lux['path']}`)
               runMode = 'lux'
             }
             

--- a/index.js
+++ b/index.js
@@ -359,4 +359,219 @@ module.exports = function(app) {
 			        default: 'mode'
 			      },
             // Resync Section
-            Res
+            Resync: {
+              title: 'Device Power-On Resync',
+              description: 'Force a settings update when a device (i.e., chartplotter) appears after being offline.',
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  path: {
+                    type: 'string',
+                    title: 'Trigger Path (e.g. navigation.courseOverGround, or navigation.currentRoute.name - See README)',
+                    default: ''
+                  },
+                  source: {
+                    type: 'string',
+                    title: 'Source ID (e.g. N2K.115). Leave empty to match any source.',
+                    default: ''
+                  },
+                  timeout: {
+                    type: 'number',
+                    title: 'Inactivity Timeout (seconds). Resend settings if data is seen after this many seconds of silence.',
+                    default: 60
+                  }
+                }
+              }
+            },
+			      Mode: {
+			        title: 'Mode based settings',
+			        description: 'Adjust the display mode based on `environment.mode` (derived-data). Below the backlight level can be set for day and night mode.',
+			        type: 'object',
+			        properties: {
+			          updateOnce: {
+			            type: 'boolean',
+			            title: 'Update display mode only when environment.mode changes.',
+			            default: true,
+			          },
+			          dayLevel: {
+			            type: 'number',
+			            title: 'Backlight level in day mode (1-10)',
+			            default: 6,
+			          },
+			          nightLevel: {
+			            type: 'number',
+			            title: 'Backlight level in night mode (1-10)',
+			            default: 3,
+			          }
+			        }
+			      },
+			      Sun: {
+			        title: 'Sun based settings',
+			        description: 'Adjust the display mode based on `environment.sun` (derived-data). Below the display mode and backlight level can be set for each mode.',
+			        type: 'object',
+			        properties: {
+			          updateOnce: {
+			            type: 'boolean',
+			            title: 'Update display mode only when environment.sun changes.',
+			            default: true,
+			          },
+			          dawn: {
+			            type: 'object',
+			            title: 'Dawn',
+			            properties: {
+			              mode: {
+			                type: 'string',
+			                title: 'Select day or night mode',
+			                enum: ['day', 'night'],
+			                enumNames: ['Day', 'Night'],
+			                default: 'night'
+			              },
+			              backlight: {
+			                type: 'number',
+			                title: 'Backlight level in nightmode (1-10)',
+			                default: 4,
+			              },
+			            },
+			          },
+			          sunrise: {
+			            type: 'object',
+			            title: 'Sunrise',
+			            properties: {
+			              mode: {
+			                type: 'string',
+			                title: 'Select day or night mode',
+			                enum: ['day', 'night'],
+			                enumNames: ['Day', 'Night'],
+			                default: 'day'
+			              },
+			              backlight: {
+			                type: 'number',
+			                title: 'Backlight level in nightmode (1-10)',
+			                default: 4,
+			              },
+			            },
+			          },
+			          day: {
+			            type: 'object',
+			            title: 'Day',
+			            properties: {
+			              mode: {
+			                type: 'string',
+			                title: 'Select day or night mode',
+			                enum: ['day', 'night'],
+			                enumNames: ['Day', 'Night'],
+			                default: 'day'
+			              },
+			              backlight: {
+			                type: 'number',
+			                title: 'Backlight level in day mode (1-10)',
+			                default: 6,
+			              },
+			            },
+			          },
+			          sunset: {
+			            type: 'object',
+			            title: 'Sunset',
+			            properties: {
+			              mode: {
+			                type: 'string',
+			                title: 'Select day or night mode',
+			                enum: ['day', 'night'],
+			                enumNames: ['Day', 'Night'],
+			                default: 'day'
+			              },
+			              backlight: {
+			                type: 'number',
+			                title: 'Backlight level in nightmode (1-10)',
+			                default: 4,
+			              },
+			            },
+			          },
+			          dusk: {
+			            type: 'object',
+			            title: 'Dusk',
+			            properties: {
+			              mode: {
+			                type: 'string',
+			                title: 'Select day or night mode',
+			                enum: ['day', 'night'],
+			                enumNames: ['Day', 'Night'],
+			                default: 'night'
+			              },
+			              backlight: {
+			                type: 'number',
+			                title: 'Backlight level in day mode (1-10)',
+			                default: 4,
+			              },
+			            },
+			          },
+			          night: {
+			            type: 'object',
+			            title: 'Night',
+			            properties: {
+			              mode: {
+			                type: 'string',
+			                title: 'Select day or night mode',
+			                enum: ['day', 'night'],
+			                enumNames: ['Day', 'Night'],
+			                default: 'night'
+			              },
+			              backlight: {
+			                type: 'number',
+			                title: 'Backlight level in nightmode (1-10)',
+			                default: 2,
+			              },
+			            },
+			          },
+			        },
+			      },
+			            
+			      Lux: {
+			        title: 'Lux based settings',
+			        description: 'Adjust the display mode based on `environment.outside.lux`. Below the display mode and backlight level can be added per lux range.',
+			        type: 'object',
+			        properties: {
+			          path: {
+			            type: 'string',
+			            title: 'Path to outside lux value',
+			            default: 'environment.outside.lux'
+			          },
+			          table: {
+			            type: 'array',
+			            title: 'Table entries',
+			            items: {
+			              type: 'object',
+			              properties: {
+			                luxMin: {
+			                  type: 'number',
+			                  title: 'Minimal lux (lux) level'
+			                },
+			                luxMax: {
+			                  type: 'number',
+			                  title: 'Max lux (lux) level'
+			                },
+			                dayNight: {
+			                  type: 'string',
+			                  title: 'Mode',
+			                  enum: ['day', 'night'],
+			                  enumNames: ['Day', 'Night'],
+			                  default: 'day'
+			                },
+			                backlightLevel: {
+			                  type: 'number',
+			                  title: 'Backlight level (1-10)',
+			                  default: 2
+			                }
+			              }
+			            }
+			          }
+			        }
+			      }
+          }
+        }
+      }
+    }
+  }
+  return plugin
+}

--- a/index.js
+++ b/index.js
@@ -394,24 +394,6 @@ module.exports = function(app) {
 			              },
 			            },
 			          },
-			          nauticalDusk: {
-			            type: 'object',
-			            title: 'Nautical Dusk',
-			            properties: {
-			              mode: {
-			                type: 'string',
-			                title: 'Select day or night mode',
-			                enum: ['day', 'night'],
-			                enumNames: ['Day', 'Night'],
-			                default: 'night'
-			              },
-			              backlight: {
-			                type: 'number',
-			                title: 'Backlight level in nautical dusk (1-10)',
-			                default: 3,
-			              },
-			            },
-			          },
 			          dusk: {
 			            type: 'object',
 			            title: 'Dusk',
@@ -427,6 +409,24 @@ module.exports = function(app) {
 			                type: 'number',
 			                title: 'Backlight level in dusk (1-10)',
 			                default: 4,
+			              },
+			            },
+			          },
+			          nauticalDusk: {
+			            type: 'object',
+			            title: 'Nautical Dusk',
+			            properties: {
+			              mode: {
+			                type: 'string',
+			                title: 'Select day or night mode',
+			                enum: ['day', 'night'],
+			                enumNames: ['Day', 'Night'],
+			                default: 'night'
+			              },
+			              backlight: {
+			                type: 'number',
+			                title: 'Backlight level in nautical dusk (1-10)',
+			                default: 3,
 			              },
 			            },
 			          },

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ module.exports = function(app) {
   plugin.start = function(options, restartPlugin) {
     plugin.options = options;
     app.debug('Plugin started');
+    app.debug('Schema: %s', JSON.stringify(options));
     
     // Local state variables
     var runMode = 'mode';
@@ -86,13 +87,14 @@ module.exports = function(app) {
       },
       delta => {
         delta.updates.forEach(u => {
-          // Standard variables
-          var path = u['values'][0]['path']
+          app.debug('u: %s', JSON.stringify(u))
+		  var path = u['values'][0]['path']
           var value = u['values'][0]['value']
           var source = u['source'] ? u['source']['label'] : delta.source ? delta.source.label : 'unknown'; 
           
           options.config.forEach(config => {
             var group = config.group;
+            app.debug(`RunMode: ${runMode} group: ${group}`)
 
             // --------------------------------------------------------
             // Resync Logic
@@ -140,9 +142,11 @@ module.exports = function(app) {
 
             //always use external control if selected
             if (config.source == 'none')
+				aap.debug("
               return;
         
             if (config.source == 'lux' && config.Lux && path == config.Lux.path) { 
+              app.debug('Switching to runMode \'lux\' luxPath: ${config.Lux['path']}')
               runMode = 'lux'
             }
             
@@ -163,6 +167,7 @@ module.exports = function(app) {
 	              }
                   
                   if (config['source'] != 'mode') { 
+                    app.debug('Used backup mode \'mode\', switching to \'sun\'')
                     runMode = 'sun'
                   }
 	              break;
@@ -170,6 +175,8 @@ module.exports = function(app) {
 	            case 'sun':
 	              if (path != 'environment.sun') break;
 	              var sunMode = value
+		          app.debug('environment.sun: %s', sunMode);
+
 	              if (!config.Sun[sunMode]) break; // Safety check
 
 	              var mode = config.Sun[sunMode]['mode'];


### PR DESCRIPTION
Hello Hans,

I added a new feature to your tool that allows for displays to "auto-recover" the correct brightness settings after being turned back on in daylight when they were last used at night and am creating this PR for your consideration.

I created new fields in the Schema that allows selection of a Source/Path to watch.  When that source/path is see again after not being see for greater than "timeout" time, the plugin we send the correct brightness/mode for the current time of day.  

I like to have "Update display mode only when environment.sun changes." checked so that I can locally override the display brightness settings with my B&G Netowkr groups, and not have it reset the next time a new environment.sun message is received, however, when I turn the chartplotter off in a "night" mode and turn in back on in a day mode, I can't see the screen at all.  I know the Power button can be tapped to cycle through brightness presets, but I wanted to expand on your tool to add this feature.

This has been tested and works wonderfully.  I sent a PR for the addition of nauticalDawn and nauticalDusk.  This PR incorporates those changes as well and have now been thoroughly tested by me without issue.

Thanks for the plugin and for considering!
Mike