### PR TITLE
Add delay between changing modes and backlight level

### DIFF
--- a/index.js
+++ b/index.js
@@ -227,7 +227,10 @@ module.exports = function(app) {
         
         // app.debug(`Executing command for Group ${group}: Mode=${mode}, Level=${level}`);
         setDisplayMode(mode, group);
-        setBacklightLevel(level, group);
+		// add a delay to the backlight level so the instrument can finish drawing from day to night mode, avoiding crashes
+		setTimeout(() => {
+            setBacklightLevel(level, group);
+        }, 1000);
         sendUpdate(mode, level);
     }
     


### PR DESCRIPTION
I have a system with a Zeus 3s and 2x triton 2 displays. One triton routinely crashes and gets out of sync with the display group. I found this was due to the backlight change being made too soon after the change to day or night mode. By adding a small delay my system is stable and stays in sync.